### PR TITLE
Server: Resolves #1: Quick fix for "missing field type_" issue

### DIFF
--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -476,7 +476,7 @@ export default class BaseItem extends BaseModel {
 
 	static async unserialize(content: string) {
 		const lines = content.split('\n');
-		let output: any = {};
+		let output: any = { type_: BaseItem.TYPE_NOTE };
 		let state = 'readingProps';
 		const body: string[] = [];
 


### PR DESCRIPTION
QuickFix to get around "Missing required property: type_" message intermittently showing up and spoiling a Client/Server synchronization.

**This is a dubious fix**, from a coder who has only spent a couple of days working with the code.

I don't claim to have in-depth knowledge of how the Client/Server sync is intended to operate. It's a "works for me" tweak that suits my needs with developing MySQL-database support for the time being.